### PR TITLE
Added Fix for geom fields which are quoted

### DIFF
--- a/src/main/scala/com/esri/MainApp.scala
+++ b/src/main/scala/com/esri/MainApp.scala
@@ -73,7 +73,9 @@ object MainApp extends App with Logging {
         iter.flatMap(line => {
           try {
             val splits = line.split(polygonSep, -1)
-            val geom = wktReader.read(splits(polygonWKT))
+            var geomString=splits(polygonWKT)
+            geomString=geomString.replaceAll("\"", "")
+            val geom = wktReader.read(geomString)
             if (geom.getEnvelopeInternal.intersects(envp))
               Some(FeaturePolygon(geom, polygonIdx.map(splits(_))))
             else


### PR DESCRIPTION
Some Software including QGIS creates TSV files which could have the Polygon's WKT quoted using double inverted commas.

This commit will fix the code, so that it can read the wkt from such fields.